### PR TITLE
KeyPath based relationships

### DIFF
--- a/Sources/CoreDataModelDescription/CoreDataRelationshipDescription.swift
+++ b/Sources/CoreDataModelDescription/CoreDataRelationshipDescription.swift
@@ -8,7 +8,6 @@
 
 import CoreData
 
-
 public struct CoreDataRelationshipDescription {
 
     public static func relationship(
@@ -37,4 +36,36 @@ public struct CoreDataRelationshipDescription {
     public var deleteRule: NSDeleteRule
 
     public var inverse: String?
+}
+
+extension CoreDataRelationshipDescription {
+
+    /// create a relationship from an NSManagedObject KeyPath, the inverse relationship another NSManagedObject KeyPath, and given delete rule
+    public static func relationship<Root, Value, InverseRoot, InverseValue>(_ keyPath: KeyPath<Root, Value>, inverse: KeyPath<InverseRoot, InverseValue>, deleteRule: NSDeleteRule = .nullifyDeleteRule) -> CoreDataRelationshipDescription where Root: NSManagedObject, InverseRoot: NSManagedObject {
+        assert(keyPath.destinationType is NSManagedObject.Type)
+        assert(inverse.destinationType is NSManagedObject.Type)
+
+        return relationship(
+            name: keyPath.stringValue,
+            destination: "\(keyPath.destinationType)",
+            optional: keyPath.isOptional,
+            toMany: keyPath.isToMany,
+            deleteRule: deleteRule,
+            inverse: inverse.stringValue
+        )
+    }
+
+    /// create a relationship from an NSManagedObject KeyPath and given delete rule
+    public static func relationship<Root, Value>(_ keyPath: KeyPath<Root, Value>, deleteRule: NSDeleteRule = .nullifyDeleteRule) -> CoreDataRelationshipDescription where Root: NSManagedObject {
+        assert(keyPath.destinationType is NSManagedObject.Type)
+
+        return relationship(
+            name: keyPath.stringValue,
+            destination: "\(keyPath.destinationType)",
+            optional: keyPath.isOptional,
+            toMany: keyPath.isToMany,
+            deleteRule: deleteRule,
+            inverse: nil
+        )
+    }
 }

--- a/Sources/CoreDataModelDescription/KeyPath+Extensions.swift
+++ b/Sources/CoreDataModelDescription/KeyPath+Extensions.swift
@@ -1,0 +1,81 @@
+//
+//  KeyPath+Extensions.swift
+//  CoreDataModelDescription
+//  
+//
+//  Created by Nate Rivard on 03/01/2020.
+//  Copyright © 2019 Dmytro Anokhin. All rights reserved.
+//
+
+import Foundation
+
+extension KeyPath {
+
+    /// returns the Root object type
+    var rootType: Any.Type {
+        return Root.self
+    }
+
+    /// returns the unwrapped `Value.Type` (if optional), or `Value.self` otherwise.
+    /// For example, if self == KeyPath<NSManagedObject, String>, then `valueType` is `String.Type`
+    /// if self == KeyPath<NSManagedObject, String?>, then `valueType` is `String.Type`, not `Optional<String>.Type`
+    var unwrappedType: Any.Type {
+        guard let optionalType = Value.self as? OptionalProtocol.Type else {
+            return Value.self
+        }
+
+        return optionalType.wrappedType
+    }
+
+    /// returns the end destination (as defined by Core Data) type, ignoring optionality and ignoring any kind of collection wrapper.
+    /// For example, if self == KeyPath<NSManagedObject, String?>, then `destinationType` is `String.Type`
+    /// if self == KeyPath<NSManagedObject, Set<String>>, then `destinationType` is also `String.Type`
+    var destinationType: Any.Type {
+        let unwrapped = unwrappedType
+
+        guard let toManyType = unwrapped.self as? ToManyProtocol.Type else {
+            return unwrapped
+        }
+
+        return toManyType.elementType
+    }
+
+    /// returns this keypath as a `String` value. This will crash if `Value` is not `@objc`. Luckily, `@NSManaged` properties satisfy this requirement.
+    var stringValue: String {
+        return NSExpression(forKeyPath: self).keyPath
+    }
+
+    /// returns whether the underlying `Value` type (as defined by `valueType`), is considered a `toMany` relationship
+    var isToMany: Bool {
+        return unwrappedType is ToManyProtocol.Type
+    }
+
+    /// returns whether `Value.self` is wrapped as an optional type. This does _not_ use `destinationType`.
+    var isOptional: Bool {
+        return Value.self is OptionalProtocol.Type
+    }
+}
+
+/// Type-erasure protocol to determine a) if `Value` is `Optional`, and b) the underlying `Wrapped` type
+protocol OptionalProtocol {
+    static var wrappedType: Any.Type { get }
+}
+
+extension Optional: OptionalProtocol {
+    static var wrappedType: Any.Type {
+        return Wrapped.self
+    }
+}
+
+/// Type-erasure protocol to determine a) if `Value` is a `Set`, and b) the underlying `Element` type
+/// NOTE: `NSSet` and `NSOrderedSet` are not supported as there is no way to determine what it's underlying `Element` type is.
+///  They are type erased as `Any`.
+protocol ToManyProtocol {
+    static var elementType: Any.Type { get }
+}
+
+extension Set: ToManyProtocol {
+    static var elementType: Any.Type {
+        return Element.self
+    }
+}

--- a/Tests/CoreDataModelDescriptionTests/CoreDataModelDescriptionTests.swift
+++ b/Tests/CoreDataModelDescriptionTests/CoreDataModelDescriptionTests.swift
@@ -8,7 +8,7 @@ final class Author: NSManagedObject {
 
     @NSManaged var name: String?
 
-    @NSManaged public var publications: NSSet?
+    @NSManaged public var publications: Set<Publication>?
 }
 
 class Publication: NSManagedObject {
@@ -189,7 +189,84 @@ final class CoreDataModelDescriptionTests: XCTestCase {
 
         try context.save()
     }
-    
+
+    func testCoreDataModelDescriptionWithKeypaths() throws {
+        let modelDescription = CoreDataModelDescription(
+            entities: [
+                .entity(
+                    name: "User",
+                    managedObjectClass: User.self,
+                    parentEntity: nil,
+                    attributes: [
+                        .attribute(name: "email", type: .stringAttributeType)
+                    ],
+                    configuration: "UserData"),
+                .entity(
+                    name: "Author",
+                    managedObjectClass: Author.self,
+                    parentEntity: nil,
+                    attributes: [
+                        .attribute(name: "name", type: .stringAttributeType)
+                    ],
+                    relationships: [
+                        .relationship(\Author.publications, inverse: \Publication.author, deleteRule: .cascadeDeleteRule)
+                    ],
+                    configuration: "News"),
+                .entity(
+                    name: "Publication",
+                    managedObjectClass: Publication.self,
+                    parentEntity: nil,
+                    attributes: [
+                        .attribute(name: "publicationDate", type: .dateAttributeType),
+                        .attribute(name: "numberOfViews", type: .integer64AttributeType, isOptional: true)
+                    ],
+                    relationships: [
+                        .relationship(\Publication.author, inverse: \Author.publications)
+                    ],
+                    configuration: "News"),
+                .entity(
+                    name: "Story",
+                    managedObjectClass: Story.self,
+                    parentEntity: "Publication",
+                    attributes: [
+                        .attribute(name: "videoURL", type: .URIAttributeType)
+                    ],
+                    configuration: "News"),
+                .entity(
+                    name: "Article",
+                    managedObjectClass: Article.self,
+                    parentEntity: "Publication",
+                    attributes: [
+                        .attribute(name: "text", type: .stringAttributeType)
+                    ],
+                    configuration: "News")
+            ]
+        )
+
+        let container = makePersistentContainer(name: "CoreDataModelDescriptionTest", modelDescription: modelDescription, configurations: ["UserData", "News"])
+        let context = container.viewContext
+
+        let user = NSEntityDescription.insertNewObject(forEntityName: "User", into: context) as! User
+        user.email = "john.doe@apple.com"
+
+        let author = NSEntityDescription.insertNewObject(forEntityName: "Author", into: context) as! Author
+        author.name = "John Doe"
+
+        let articleDate = Date()
+        let storyDate = articleDate.addingTimeInterval(60.0)
+
+        let article = NSEntityDescription.insertNewObject(forEntityName: "Article", into: context) as! Article
+        article.publicationDate = articleDate
+        article.text = "This is an article"
+        article.author = author
+
+        let story = NSEntityDescription.insertNewObject(forEntityName: "Story", into: context) as! Story
+        story.publicationDate = storyDate
+        story.videoURL = URL(string: "https://video")
+        story.author = author
+
+        try context.save()
+    }
     
     static var allTests = [
         ("testCoreDataModelDescription", testCoreDataModelDescription),

--- a/Tests/CoreDataModelDescriptionTests/CoreDataModelRelationshipDescriptionTests.swift
+++ b/Tests/CoreDataModelDescriptionTests/CoreDataModelRelationshipDescriptionTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import CoreData
+@testable import CoreDataModelDescription
+
+final class CoreDataModelRelationshipDescriptionTests: XCTestCase {
+
+    final class Parent: NSManagedObject {
+        @NSManaged var children: Set<Child>
+    }
+
+    final class Child: NSManagedObject {
+        @NSManaged var parent: Parent?
+    }
+
+    func testCreateRelationshipWithKeyPath() {
+        let relationship: CoreDataRelationshipDescription = .relationship(\Child.parent)
+
+        XCTAssert(relationship.optional)
+        XCTAssertEqual(relationship.maxCount, 1)
+        XCTAssertEqual(relationship.name, "parent")
+        XCTAssertEqual(relationship.destination, "Parent")
+        XCTAssertNil(relationship.inverse)
+        XCTAssertEqual(relationship.deleteRule, .nullifyDeleteRule)
+    }
+
+    func testCreateToManyRelationshipWithKeyPath() {
+        let relationship: CoreDataRelationshipDescription = .relationship(\Parent.children)
+
+        XCTAssertFalse(relationship.optional)
+        XCTAssertEqual(relationship.maxCount, 0)
+        XCTAssertEqual(relationship.name, "children")
+        XCTAssertEqual(relationship.destination, "Child")
+        XCTAssertNil(relationship.inverse)
+        XCTAssertEqual(relationship.deleteRule, .nullifyDeleteRule)
+    }
+
+    func testCreateRelationshipWithInverseKeyPath() {
+        let relationship: CoreDataRelationshipDescription = .relationship(\Parent.children, inverse: \Child.parent)
+        XCTAssertEqual(relationship.inverse, "parent")
+    }
+
+    func testRelationshipsEquivalent() {
+        let relationship: CoreDataRelationshipDescription = .relationship(name: "children", destination: "Child", optional: false, toMany: true, inverse: "parent")
+        let keypathRelationship: CoreDataRelationshipDescription = .relationship(\Parent.children, inverse: \Child.parent)
+
+        XCTAssertEqual(relationship.name, keypathRelationship.name)
+        XCTAssertEqual(relationship.destination, keypathRelationship.destination)
+        XCTAssertEqual(relationship.maxCount, keypathRelationship.maxCount)
+        XCTAssertEqual(relationship.optional, keypathRelationship.optional)
+        XCTAssertEqual(relationship.deleteRule, keypathRelationship.deleteRule)
+        XCTAssertEqual(relationship.inverse, keypathRelationship.inverse)
+    }
+}

--- a/Tests/CoreDataModelDescriptionTests/KeyPathExtensionTests.swift
+++ b/Tests/CoreDataModelDescriptionTests/KeyPathExtensionTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import CoreData
+@testable import CoreDataModelDescription
+
+final class KeyPathExtensionTests: XCTestCase {
+
+    final class TestModel: NSObject {
+        @objc var string: String = "test"
+        @objc var optionalString: String?
+
+        @objc var set: Set<String> = []
+        @objc var optionalSet: Set<String>?
+    }
+
+    func testKeyPathRootType() {
+        let keypath = \TestModel.string
+        XCTAssert(keypath.rootType is TestModel.Type)
+    }
+
+    func testKeyPathDestinationType() {
+        let stringPath = \TestModel.string
+        XCTAssert(stringPath.destinationType is String.Type)
+
+        let optionalStringPath = \TestModel.optionalString
+        XCTAssert(optionalStringPath.destinationType is String.Type)
+
+        let setPath = \TestModel.set
+        XCTAssert(setPath.destinationType is String.Type)
+        XCTAssertFalse(setPath.destinationType is Optional<Set<String>>.Type)
+        XCTAssertFalse(setPath.destinationType is Set<AnyHashable>.Type)
+
+        let optionalSetPath = \TestModel.optionalSet
+        XCTAssert(optionalSetPath.destinationType is String.Type)
+    }
+
+    func testKeyPathStringValue() {
+        let keypath = \TestModel.string
+        XCTAssertEqual(keypath.stringValue, "string")
+    }
+
+    func testKeyPathIsToMany() {
+        let stringPath = \TestModel.string
+        XCTAssertFalse(stringPath.isToMany)
+
+        let optionalStringPath = \TestModel.optionalString
+        XCTAssertFalse(optionalStringPath.isToMany)
+
+        let setPath = \TestModel.set
+        XCTAssert(setPath.isToMany)
+
+        let optionalSetPath = \TestModel.optionalSet
+        XCTAssert(optionalSetPath.isToMany)
+    }
+
+    func testKeyPathIsOptional() {
+        let string = \TestModel.string
+        XCTAssertFalse(string.isOptional)
+
+        let optionalString = \TestModel.optionalString
+        XCTAssert(optionalString.isOptional)
+    }
+}


### PR DESCRIPTION
This change proposes a more succinct, boilerplate-free way to express relationships that also enhances compile time safety.

For example, given the following model:
```swift
final class Parent: NSManagedObject {
    @NSManaged var children: Set<Child>
}

final class Child: NSManagedObject {
    @NSManaged var parent: Parent?
}
```

With current API, you would instantiate the `children` relationship as:
```swift
let relationship: CoreDataRelationshipDescription = .relationship(
    name: "children", 
    destination: "Child", 
    optional: false, 
    toMany: true, 
    inverse: "parent"
)
```

With this change, you could express it as:
```swift
let relationship: CoreDataRelationshipDescription = .relationship(\Parent.children, inverse: \Child.parent)
```
This has a number of advantages such as at compile time, the compiler will check that `\Parent.children` and `\Child.parent` both exist (in addition to code completion) and at runtime will pull relevant type information from the `Value` that this KeyPath points to, freeing up error-prone boilerplate regarding optionality, is it a to-many relationship, etc.

In addition, I added a ton of tests to verify correctness and duplicated some existing tests that use this new pathway to verify equivalence.