### PR TITLE
Exposed `isAbstract` flag

### DIFF
--- a/Sources/CoreDataModelDescription/CoreDataEntityDescription.swift
+++ b/Sources/CoreDataModelDescription/CoreDataEntityDescription.swift
@@ -16,12 +16,13 @@ public struct CoreDataEntityDescription {
     public static func entity(name: String,
                               managedObjectClass: NSManagedObject.Type = NSManagedObject.self,
                               parentEntity: String? = nil,
+                              isAbstract: Bool = false,
                               attributes: [CoreDataAttributeDescription] = [],
                               fetchedProperties: [CoreDataFetchedPropertyDescription] = [],
                               relationships: [CoreDataRelationshipDescription] = [],
                               indexes: [CoreDataFetchIndexDescription] = [],
                               configuration: String? = nil) -> CoreDataEntityDescription {
-        CoreDataEntityDescription(name: name, managedObjectClassName: NSStringFromClass(managedObjectClass), parentEntity: parentEntity, attributes: attributes, fetchedProperties: fetchedProperties, relationships: relationships, indexes: indexes, configuration: configuration)
+        CoreDataEntityDescription(name: name, managedObjectClassName: NSStringFromClass(managedObjectClass), parentEntity: parentEntity, isAbstract: isAbstract, attributes: attributes, fetchedProperties: fetchedProperties, relationships: relationships, indexes: indexes, configuration: configuration)
     }
 
     public var name: String
@@ -29,6 +30,8 @@ public struct CoreDataEntityDescription {
     public var managedObjectClassName: String
 
     public var parentEntity: String?
+
+    public var isAbstract: Bool
 
     public var attributes: [CoreDataAttributeDescription]
     

--- a/Sources/CoreDataModelDescription/CoreDataModelDescription.swift
+++ b/Sources/CoreDataModelDescription/CoreDataModelDescription.swift
@@ -41,6 +41,7 @@ public struct CoreDataModelDescription {
             let entity = NSEntityDescription()
             entity.name = entityDescription.name
             entity.managedObjectClassName = entityDescription.managedObjectClassName
+            entity.isAbstract = entityDescription.isAbstract
 
             var propertyNameToProperty: [String: NSPropertyDescription] = [:]
 

--- a/Tests/CoreDataModelDescriptionTests/CoreDataModelDescriptionTests.swift
+++ b/Tests/CoreDataModelDescriptionTests/CoreDataModelDescriptionTests.swift
@@ -267,6 +267,27 @@ final class CoreDataModelDescriptionTests: XCTestCase {
 
         try context.save()
     }
+
+    func testAbstractEntity() {
+        class Abstract: NSManagedObject {
+            @NSManaged var name: String
+        }
+
+        final class Concrete: Abstract {
+            @NSManaged var id: Int
+        }
+
+        let modelDescription = CoreDataModelDescription(entities: [
+            .entity(name: "Abstract", managedObjectClass: Abstract.self, isAbstract: true, attributes: [.attribute(name: "name", type: .stringAttributeType)]),
+            .entity(name: "Concrete", managedObjectClass: Concrete.self, parentEntity: "Abstract", attributes: [.attribute(name: "id", type: .integer64AttributeType)])
+        ])
+
+        let container = makePersistentContainer(name: "CoreDataModelDescriptionTest", modelDescription: modelDescription)
+        let context = container.viewContext
+
+        let abstractEntityDescription = NSEntityDescription.entity(forEntityName: "Abstract", in: context)
+        XCTAssert(abstractEntityDescription?.isAbstract == true, "Entity is not marked as abstract in entity model")
+    }
     
     static var allTests = [
         ("testCoreDataModelDescription", testCoreDataModelDescription),


### PR DESCRIPTION
This change exposes the `isAbstract` flag on `NSEntityDescription` so we can properly mark entities as non-instantiable.  It also adds a test to verify that this change is reflected in the real model.